### PR TITLE
Added client credentials grant + implemented token revocation

### DIFF
--- a/src/ThinKingMik/ApiProxy/Exceptions/ResponseParseErrorException.php
+++ b/src/ThinKingMik/ApiProxy/Exceptions/ResponseParseErrorException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package   thinkingmik/api-proxy-laravel
+ * @author    Michele Andreoli <michi.andreoli[at]gmail.com>
+ * @copyright Copyright (c) Michele Andreoli
+ * @license   http://mit-license.org/
+ * @link      https://github.com/thinkingmik/api-proxy-laravel
+ */
+
+namespace ThinKingMik\ApiProxy\Exceptions;
+
+/**
+ * Exception class
+ */
+class ResponseParseErrorException extends ProxyException {
+
+    public function __construct() {
+	    $this->httpStatusCode = 500;
+	    $this->errorType = 'proxy_response_parse_error';
+        parent::__construct(\Lang::get('api-proxy-laravel::messages.proxy_response_parse_error'));
+    }
+
+}

--- a/src/ThinKingMik/ApiProxy/Managers/RequestManager.php
+++ b/src/ThinKingMik/ApiProxy/Managers/RequestManager.php
@@ -15,6 +15,7 @@ use ThinKingMik\ApiProxy\Models\ProxyResponse;
 use ThinKingMik\ApiProxy\Models\MixResponse;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use ThinKingMik\ApiProxy\Exceptions\MissingClientSecretException;
 
 class RequestManager {
@@ -200,6 +201,9 @@ class RequestManager {
             $response = $client->send($request);
         }
         catch (ClientException $ex) {
+            $response = $ex->getResponse();
+        }
+        catch (ServerException $ex) {
             $response = $ex->getResponse();
         }
 

--- a/src/ThinKingMik/ApiProxy/Proxy.php
+++ b/src/ThinKingMik/ApiProxy/Proxy.php
@@ -22,6 +22,7 @@ class Proxy {
     private $callMode = null;
     private $uriParam = null;
     private $skipParam = null;
+    private $revokeParam = null;
     private $redirectUri = null;
     private $clientSecrets = null;
     private $cookieManager = null;
@@ -33,6 +34,7 @@ class Proxy {
     public function __construct($params) {
         $this->uriParam = $params['uri_param'];
         $this->skipParam = $params['skip_param'];
+        $this->revokeParam = $params['revoke_param'];
         $this->redirectUri = $params['redirect_login'];
         $this->clientSecrets = $params['client_secrets'];
         $this->useHeader = $params['use_header'];
@@ -57,6 +59,7 @@ class Proxy {
         //Remove parameters from inputs
         $inputs = ProxyAux::removeQueryValue($inputs, $this->uriParam);
         $inputs = ProxyAux::removeQueryValue($inputs, $this->skipParam);
+        $inputs = ProxyAux::removeQueryValue($inputs, $this->revokeParam);
 
         //Read the cookie if exists
         $parsedCookie = null;
@@ -99,6 +102,7 @@ class Proxy {
     private function getRequestMode($inputs) {
         $grantType = ProxyAux::getQueryValue($inputs, ProxyAux::GRANT_TYPE);
         $skip = ProxyAux::getQueryValue($inputs, $this->skipParam);
+        $revoke = ProxyAux::getQueryValue($inputs, $this->revokeParam);
         $mode = ProxyAux::MODE_TOKEN;
 
         if (isset($grantType)) {
@@ -108,6 +112,9 @@ class Proxy {
         }
         else if (isset($skip) && strtolower($skip) === 'true') {
             $mode = ProxyAux::MODE_SKIP;
+        }
+        else if (isset($revoke) && strtolower($revoke) === 'true') {
+            $mode = ProxyAux::MODE_REVOKE;
         }
 
         return $mode;

--- a/src/ThinKingMik/ApiProxy/Proxy.php
+++ b/src/ThinKingMik/ApiProxy/Proxy.php
@@ -102,7 +102,7 @@ class Proxy {
         $mode = ProxyAux::MODE_TOKEN;
 
         if (isset($grantType)) {
-            if ($grantType === ProxyAux::PASSWORD_GRANT) {
+            if ($grantType === ProxyAux::PASSWORD_GRANT || $grantType === ProxyAux::CLIENT_CREDENTIALS_GRANT) {
                 $mode = ProxyAux::MODE_LOGIN;
             }
         }

--- a/src/ThinKingMik/ApiProxy/ProxyAux.php
+++ b/src/ThinKingMik/ApiProxy/ProxyAux.php
@@ -22,6 +22,7 @@ class ProxyAux {
     const COOKIE_URI = 'uri';
     const COOKIE_METHOD = 'method';
     const PASSWORD_GRANT = 'password';
+    const CLIENT_CREDENTIALS_GRANT = 'client_credentials';
     const HEADER_AUTH = "Authorization";
     const MODE_SKIP = '0';
     const MODE_LOGIN = '1';

--- a/src/ThinKingMik/ApiProxy/ProxyAux.php
+++ b/src/ThinKingMik/ApiProxy/ProxyAux.php
@@ -28,6 +28,9 @@ class ProxyAux {
     const MODE_LOGIN = '1';
     const MODE_TOKEN = '2';
     const MODE_REFRESH = '3';
+    const MODE_REVOKE = '4';
+    const REVOKE_TOKEN = 'token';
+    const REVOKE_TOKEN_TYPE_HINT = 'token_type_hint';
 
     /**
      * @param $array

--- a/src/config/proxy.php
+++ b/src/config/proxy.php
@@ -34,6 +34,17 @@ return [
 
     /*
       |--------------------------------------------------------------------------
+      | Proxy input: define the revoke attribute
+      |--------------------------------------------------------------------------
+      |
+      | When you call the proxy helper with this attribute set as true, this will be
+      | the last call after which the cookie will be destroyed.
+      |
+     */
+    'revoke_param' => 'revoke',
+
+    /*
+      |--------------------------------------------------------------------------
       | Set redirect URI
       |--------------------------------------------------------------------------
       |

--- a/src/lang/en/messages.php
+++ b/src/lang/en/messages.php
@@ -13,5 +13,6 @@ return array(
 	'proxy_missing_param' => 'Missing mandatory parameter <b>:param</b> in the request call',
 	'missing_client_secret' => 'Missing secret key for client id <b>:client</b>',
 	'proxy_cookie_expired' => 'Cookie expired or not found. Return to the login form.',
-	'proxy_cookie_invalid' => 'Cookie format not valid. Missing attribute <b>:param</b>.'
+	'proxy_cookie_invalid' => 'Cookie format not valid. Missing attribute <b>:param</b>.',
+	'proxy_response_parse_error' => 'Response to proxy was malformed.',
 );

--- a/src/lang/it/messages.php
+++ b/src/lang/it/messages.php
@@ -13,5 +13,6 @@ return array(
 	'proxy_missing_param' => 'Manca il parametro obbligatorio <b>:param</b> nella richiesta',
 	'missing_client_secret' => 'Manca la chiave segreta per il client <b>:client</b>',
 	'proxy_cookie_expired' => 'Cookie scaduto o non trovato. Ritorna al form di login.',
-	'proxy_cookie_invalid' => 'Formato del cookie non valido. Manca l\'attributo <b>:param</b>.'
+	'proxy_cookie_invalid' => 'Formato del cookie non valido. Manca l\'attributo <b>:param</b>.',
+	'proxy_response_parse_error' => 'Risposta a proxy era valido.',
 );


### PR DESCRIPTION
Hello,
This PR includes : 
a simple modification to enable client_credentials grant with the API proxy
a bugfix for Guzzle not to fail on ServerExecption but proxy the error back to the caller
an implementation of token revocation, base on https://tools.ietf.org/html/draft-ietf-oauth-revocation-11 (I implemented it in lucadegasperi/oauth2-server-laravel and it needed this new proxy feature)
